### PR TITLE
tesseract4android project name changed so this will fail to resolve

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 	api("com.github.steve1316:opencv-android-sdk:4.7.0")
 
 	// Tesseract4Android for OCR text recognition.
-	api("cz.adaptech.android:tesseract4android:2.1.1")
+	api("cz.adaptech.tesseract4android:2.1.1")
 
 	// Twitter4j is used to connect to the Twitter API.
 	api("org.twitter4j:twitter4j-core:4.1.2")


### PR DESCRIPTION
I was trying to build your gbf automation android project and had a resolve error, which I found out is due to this library depending on Tesseract4Android which had a name change:

https://github.com/adaptech-cz/Tesseract4Android/issues/70

I was hoping you could add this PR so that it builds properly again. Thanks!