### PR TITLE
CHORE: Change randomizeTapLocation's imageName argument to a nullable string.

### DIFF
--- a/app/src/main/java/com/steve1316/automation_library/utils/MyAccessibilityService.kt
+++ b/app/src/main/java/com/steve1316/automation_library/utils/MyAccessibilityService.kt
@@ -184,12 +184,17 @@ class MyAccessibilityService : AccessibilityService() {
 	 *
 	 * @param x The original x location for the tap gesture.
 	 * @param y The original y location for the tap gesture.
-	 * @param imageName The name of the image to acquire its dimensions for tap location randomization. Defaults to an empty string which will then default to a region of 25x25.
+	 * @param imageName The name of the image to acquire its dimensions for tap location randomization. Defaults to null which will then default to a region of 25x25.
 	 * @return Pair of integers that represent the newly randomized tap location.
 	 */
-	private fun randomizeTapLocation(x: Double, y: Double, imageName: String = ""): Pair<Int, Int> {
+	private fun randomizeTapLocation(x: Double, y: Double, imageName: String? = null): Pair<Int, Int> {
 		// Get the Bitmap from the template image file inside the specified folder.
 		val templateBitmap: Bitmap
+
+        if (imageName == null) {
+            return Pair(25, 25)
+        }
+
 		val dimensions: Pair<Int, Int> = try {
 			val newImageSubFolder = if (SharedData.templateSubfolderPathName.last() != '/') {
 				"${SharedData.templateSubfolderPathName}/"
@@ -242,12 +247,12 @@ class MyAccessibilityService : AccessibilityService() {
 	 *
 	 * @param x The x coordinate of the point.
 	 * @param y The y coordinate of the point.
-	 * @param imageName The file name of the image to tap in order to extract its dimensions to perform tap randomization calculations. Defaults to an empty string.
+	 * @param imageName The file name of the image to tap in order to extract its dimensions to perform tap randomization calculations. Defaults to null.
 	 * @param longPress Whether or not to long press. Defaults to false.
 	 * @param taps How many taps to execute. Defaults to a single tap.
 	 * @return True if the tap gesture was executed successfully. False otherwise.
 	 */
-	fun tap(x: Double, y: Double, imageName: String = "", longPress: Boolean = false, taps: Int = 1): Boolean {
+	fun tap(x: Double, y: Double, imageName: String? = null, longPress: Boolean = false, taps: Int = 1): Boolean {
 		// Check if gestures are allowed and thread is not interrupted.
 		Log.d(tag, "isGestureAllowed=$isGestureAllowed, threadInterrupted=${Thread.currentThread().isInterrupted}")
 		val allowed = isGestureAllowed // Make sure we read the latest value.
@@ -265,7 +270,8 @@ class MyAccessibilityService : AccessibilityService() {
 
 		// Randomize the tapping location.
 		val (newX, newY) = randomizeTapLocation(x, y, imageName)
-		Log.d(tag, "Tapping $newX, $newY for image: ${imageName.uppercase()}")
+        val imageNameString: String = imageName ?: "NULL"
+		Log.d(tag, "Tapping $newX, $newY for image: $imageNameString")
 
 		// Construct the tap gesture.
 		val tapPath = Path().apply {


### PR DESCRIPTION
# Brief

This PR changes the `imageName` argument in the `randomizeTapLocation` function from a string to a nullable string. The default value for this parameter is also updated from an empty string to `null`.

While debugging a different issue, I ran across the following error:

<img width="980" height="69" alt="image" src="https://github.com/user-attachments/assets/e9f3b812-327f-4dc7-b1b6-fd80bfbdb79b" />

This error was triggered by calling `tap(x, y)` without any `imageName` parameter. The `tap` function then calls the `randomizeTapLocation` function with no `imageName` parameter. Since we are allowed to call these functions with no `imageName`, it does not make sense for us to log an error (or anything at all...) for this event.

# Changes

To make this function's behavior more apparent, I have changed the `imageName` parameter to a nullable string with a default value of `null`. This should make it clear that this is just an optional parameter. The `randomizeTapLocation` function now returns the `Pair(25, 25)` right away if `imageName == null`.

The error handling is still in the function so we will still log the previous error on a `FileNotFoundException`.