### PR TITLE
Fix Tesseract concurrency crash and ML Kit startup double-init crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,3 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <!--Disable ML Kit's automatic ContentProvider initialization so a rare double-init race cannot crash the consuming app at startup.-->
+        <!--ML Kit is initialized manually and defensively in ImageUtils instead.-->
+        <provider
+            android:name="com.google.mlkit.common.internal.MlKitInitProvider"
+            tools:node="remove" />
+    </application>
+
 </manifest>

--- a/app/src/main/java/com/steve1316/automation_library/utils/ImageUtils.kt
+++ b/app/src/main/java/com/steve1316/automation_library/utils/ImageUtils.kt
@@ -99,6 +99,9 @@ open class ImageUtils(protected val context: Context) {
     protected lateinit var tessBaseAPI: TessBaseAPI
     protected lateinit var tessDigitsBaseAPI: TessBaseAPI
 
+    // Single lock guarding all access to the shared, non-thread-safe Tesseract API instances above.
+    private val tesseractLock = Any()
+
     init {
         // Set the match file path to the bot's internal temp folder.
         val tempMatchFilePath: String = context.filesDir.absolutePath + "/temp"
@@ -1321,38 +1324,43 @@ open class ImageUtils(protected val context: Context) {
 
         // Fallback to Tesseract if ML Kit failed or didn't find result.
         if (mlKitFailed || result == "") {
-            // Use either the default Tesseract client or the Tesseract client geared towards digits to set the image to scan.
             Log.e(tag, errorMessage)
-            if (detectDigitsOnly) {
-                Log.d(tag, "[TEXT_DETECTION] Setting Tesseract image for digits only.")
-                tessDigitsBaseAPI.setImage(finalBitmap)
-            } else {
-                Log.d(tag, "[TEXT_DETECTION] Setting Tesseract image for text detection.")
-                tessBaseAPI.setImage(finalBitmap)
-            }
 
-            try {
-                // Finally, detect text on the cropped region.
-                result =
-                    if (detectDigitsOnly) {
-                        tessDigitsBaseAPI.utF8Text
-                    } else {
-                        tessBaseAPI.utF8Text
-                    }
-                Log.d(tag, "[TEXT_DETECTION] Detected text with Tesseract: $result")
-            } catch (e: Exception) {
-                Log.e(tag, "Cannot perform OCR: ${e.stackTraceToString()}")
-            }
+            // The Tesseract API instances are not thread-safe, so serialize all access to them with a single lock covering both instances.
+            // Concurrent OCR calls (e.g. reading several stats in parallel) can otherwise corrupt Tesseract state and crash the process with a native SIGABRT.
+            synchronized(tesseractLock) {
+                // Use either the default Tesseract client or the Tesseract client geared towards digits to set the image to scan.
+                if (detectDigitsOnly) {
+                    Log.d(tag, "[TEXT_DETECTION] Setting Tesseract image for digits only.")
+                    tessDigitsBaseAPI.setImage(finalBitmap)
+                } else {
+                    Log.d(tag, "[TEXT_DETECTION] Setting Tesseract image for text detection.")
+                    tessBaseAPI.setImage(finalBitmap)
+                }
 
-            // Stop Tesseract operations.
-            if (detectDigitsOnly) {
-                tessDigitsBaseAPI.stop()
-            } else {
-                tessBaseAPI.stop()
-            }
+                try {
+                    // Finally, detect text on the cropped region.
+                    result =
+                        if (detectDigitsOnly) {
+                            tessDigitsBaseAPI.utF8Text
+                        } else {
+                            tessBaseAPI.utF8Text
+                        }
+                    Log.d(tag, "[TEXT_DETECTION] Detected text with Tesseract: $result")
+                } catch (e: Exception) {
+                    Log.e(tag, "Cannot perform OCR: ${e.stackTraceToString()}")
+                }
 
-            tessBaseAPI.clear()
-            tessDigitsBaseAPI.clear()
+                // Stop Tesseract operations.
+                if (detectDigitsOnly) {
+                    tessDigitsBaseAPI.stop()
+                } else {
+                    tessBaseAPI.stop()
+                }
+
+                tessBaseAPI.clear()
+                tessDigitsBaseAPI.clear()
+            }
         } else {
             Log.d(tag, "[TEXT_DETECTION] Detected text with Google ML Kit: $result")
         }

--- a/app/src/main/java/com/steve1316/automation_library/utils/ImageUtils.kt
+++ b/app/src/main/java/com/steve1316/automation_library/utils/ImageUtils.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.get
 import androidx.core.graphics.scale
+import com.google.mlkit.common.MlKit
 import com.google.mlkit.common.MlKitException
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
@@ -95,6 +96,17 @@ open class ImageUtils(protected val context: Context) {
     // //////////////////////////////////////////////////////////////////
     // //////////////////////////////////////////////////////////////////
     // OCR configuration
+
+    // ML Kit's automatic ContentProvider init is disabled in the manifest to avoid a rare startup double-init crash.
+    // Initialize it here before any ML Kit client is created or used, and catch IllegalStateException so a redundant init is a no-op instead of a crash.
+    init {
+        try {
+            MlKit.initialize(context)
+        } catch (e: IllegalStateException) {
+            Log.w(tag, "ML Kit was already initialized: ${e.message}")
+        }
+    }
+
     protected val googleTextRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
     protected lateinit var tessBaseAPI: TessBaseAPI
     protected lateinit var tessDigitsBaseAPI: TessBaseAPI

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ app-buildToolsVersion = "36.0.0"
 app-minSdk = "24"
 #noinspection ExpiredTargetSdkVersion
 app-targetSdk = "30"
-app-versionName = "2.5.7"
+app-versionName = "2.5.8"
 app-jvm-toolchain = "17"
 
 


### PR DESCRIPTION
## Description

- This PR serializes all access to the shared, non-thread-safe `tessBaseAPI` and `tessDigitsBaseAPI` instances in `findText()` with a single lock, fixing a native `SIGABRT` that crashed the whole process when multiple threads hit the Tesseract OCR fallback at once (e.g. reading several stats in parallel).
- It also disables ML Kit's automatic `MlKitInitProvider` (via `tools:node="remove"` in the library manifest) and initializes ML Kit defensively in `ImageUtils` instead, fixing a rare startup crash where the auto-init provider threw `MlKitContext is already initialized`.

Original crashes:
```
(Tesseract) F libc: Fatal signal 6 (SIGABRT) in tid 4860 (Thread-22), pid 2709
    #01 libtesseract.so tesseract::ERRCODE::error(...)
    #05 libtesseract.so tesseract::TessBaseAPI::GetUTF8Text()

(ML Kit) E AndroidRuntime: java.lang.RuntimeException: Unable to get provider
    com.google.mlkit.common.internal.MlKitInitProvider:
    java.lang.IllegalStateException: MlKitContext is already initialized
```
